### PR TITLE
feat: add SdkDecEncoder

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -21,6 +21,8 @@ var (
 	ValAddressKeyEncoder KeyEncoder[sdk.ValAddress] = valAddressKeyEncoder{}
 	// ConsAddressKeyEncoder can be used to encode sdk.ConsAddress keys.
 	ConsAddressKeyEncoder KeyEncoder[sdk.ConsAddress] = consAddressKeyEncoder{}
+	// SdkDecKeyEncoder can be used to encode sdk.Dec keys.
+	SdkDecKeyEncoder KeyEncoder[sdk.Dec] = sdkDecKeyEncoder{}
 )
 
 type stringKey struct{}
@@ -116,3 +118,24 @@ func (consAddressKeyEncoder) Decode(b []byte) (int, sdk.ConsAddress) {
 	return r, consAddr
 }
 func (consAddressKeyEncoder) Stringify(key sdk.ConsAddress) string { return key.String() }
+
+type sdkDecKeyEncoder struct{}
+
+func (sdkDecKeyEncoder) Stringify(key sdk.Dec) string { return key.String() }
+
+func (sdkDecKeyEncoder) Encode(key sdk.Dec) []byte {
+	bz, err := key.Marshal()
+	if err != nil {
+		panic(fmt.Errorf("invalid DecKey: %w", err))
+	}
+	fmt.Println("sdkDecKeyEncoder.Encode", string(bz))
+	return bz
+}
+func (sdkDecKeyEncoder) Decode(b []byte) (int, sdk.Dec) {
+	var dec sdk.Dec
+	if err := dec.Unmarshal(b); err != nil {
+		panic(fmt.Errorf("invalid DecKey bytes: %w", err))
+	}
+
+	return len(b), dec
+}

--- a/keys_test.go
+++ b/keys_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestUint64(t *testing.T) {
 	t.Run("bijectivity", func(t *testing.T) {
-		assertBijective[uint64](t, Uint64KeyEncoder, uint64(0x0123456789ABCDEF))
+		assertBijective(t, Uint64KeyEncoder, uint64(0x0123456789ABCDEF))
 	})
 
 	t.Run("empty", func(t *testing.T) {
@@ -87,5 +87,15 @@ func TestTimeKey(t *testing.T) {
 func TestValAddressKey(t *testing.T) {
 	t.Run("bijective", func(t *testing.T) {
 		assertBijective(t, ValAddressKeyEncoder, sdk.ValAddress(secp256k1.GenPrivKey().PubKey().Address()))
+	})
+}
+
+func TestSdkDecKey(t *testing.T) {
+	t.Run("bijective", func(t *testing.T) {
+		assertBijective(t, SdkDecKeyEncoder, sdk.NewDec(123456789))
+	})
+
+	t.Run("zero dec", func(t *testing.T) {
+		assertBijective(t, SdkDecKeyEncoder, sdk.ZeroDec())
 	})
 }


### PR DESCRIPTION
Adds a `SdkDecEncoder` that allows one to use `sdk.Dec` objects as keys in the Collections API.

An example of storing objects keyed by `sdk.Dec` is when ordering Perp Positions by liquidation price. Liquidation price is given as an `sdk.Dec` and this allows us to build an ordered map of Perp Positions sorted by liquidation price ascending or descending.