### PR TITLE
fix: dealing with empty strings in stringKey.Decode

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -36,7 +36,7 @@ func (stringKey) Encode(s string) []byte {
 
 func (stringKey) Decode(b []byte) (int, string) {
 	l := len(b)
-	if l < 2 {
+	if l < 1 {
 		panic(fmt.Errorf(
 			"invalid StringKey bytes. StringKey must be at least length 2. %s",
 			HumanizeBytes(b)))

--- a/keys.go
+++ b/keys.go
@@ -38,7 +38,7 @@ func (stringKey) Decode(b []byte) (int, string) {
 	l := len(b)
 	if l < 1 {
 		panic(fmt.Errorf(
-			"invalid StringKey bytes. StringKey must be at least length 2. %s",
+			"invalid StringKey bytes. StringKey must be at least length 1. %s",
 			HumanizeBytes(b)))
 	}
 	for i, c := range b {

--- a/keys_test.go
+++ b/keys_test.go
@@ -44,6 +44,13 @@ func TestStringKey(t *testing.T) {
 		})
 	})
 
+	t.Run("empty string", func(t *testing.T) {
+		b := StringKeyEncoder.Encode("")
+		i, r := StringKeyEncoder.Decode(b)
+		require.Equal(t, 1, i)
+		require.Equal(t, "", r)
+	})
+
 	t.Run("proper ordering", func(t *testing.T) {
 		stringKeys := []string{
 			"a", "aa", "b", "c", "dd",


### PR DESCRIPTION
should fix: https://github.com/NibiruChain/nibiru/issues/1084

I'm not sure though if empty asset pair strings should be allowed in oracle.